### PR TITLE
Allow py.test to recognize test naming convention used by this project

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[pytest]
+python_files=*_tests.py
+python_classes=*Tests
+python_functions=test_*


### PR DESCRIPTION
Currently, the readme mentions that pytest is the preferred test runner, but by default, `py.test` does not recognize the test naming convention used in this project.

This adds a local configuration file so that `py.test` correctly finds and runs unittests under `tests`