### PR TITLE
Fix mean std color balancing

### DIFF
--- a/color_balance/colorimage.py
+++ b/color_balance/colorimage.py
@@ -116,7 +116,7 @@ def get_cdf(band, mask=None):
     """
 
     hist = get_histogram(band, mask)
-    
+
     # If the datatype of the histogram is not int, CDF calculation is off, for
     # example, CDF may never reach 1
     assert hist.dtype == np.int

--- a/color_balance/histogram_match.py
+++ b/color_balance/histogram_match.py
@@ -135,13 +135,12 @@ def _check_cdf(cdf):
 
 def mean_std_luts(in_img, ref_img, in_mask=None, ref_mask=None, dtype=np.uint16):
 
-    # Numpy masked arrays treat True as masked values. Opposite of OpenCV
     if in_mask is not None:
-        in_mask = np.tile(~in_mask, (1, 1, in_img.shape[2]))
+        in_mask = np.tile(in_mask[..., None], (1, 1, in_img.shape[2]))
         in_img = np.ma.masked_where(in_mask, in_img)
 
     if ref_mask is not None:
-        ref_mask = np.tile(~ref_mask, (1, 1, ref_img.shape[2]))
+        ref_mask = np.tile(ref_mask[..., None], (1, 1, ref_img.shape[2]))
         ref_img = np.ma.masked_where(ref_mask, ref_img)
 
     # Need to make sure we check after masking invalid values

--- a/color_balance/histogram_match.py
+++ b/color_balance/histogram_match.py
@@ -164,12 +164,22 @@ def mean_std_luts(in_img, ref_img, in_mask=None, ref_mask=None, dtype=np.uint16)
 
     out_luts = []
 
-    # minimum = np.iinfo(dtype).min
-    # maximum = np.iinfo(dtype).max
-    # test out 12bit
-    minimum = 0
-    maximum = 4096
+    if dtype == np.uint16:
+        # Assume any 16-bit images are actually 12-bit.
+        minimum = 0
+        maximum = 4096
+    else:
+        minimum = np.iinfo(dtype).min
+        maximum = np.iinfo(dtype).max
     in_lut = np.arange(minimum, maximum + 1, dtype=dtype)
+
+    # Need to rescale for 8-bit color targets...
+    if ref_img.dtype != dtype:
+        dmin = np.iinfo(ref_img.dtype).min
+        dmax = np.iinfo(ref_img.dtype).max
+
+        ref_mean = maximum * (ref_mean - dmin) / float(dmax - dmin)
+        ref_std = maximum * ref_std / float(dmax - dmin)
 
     for bidx in range(3):
 

--- a/color_balance/histogram_match.py
+++ b/color_balance/histogram_match.py
@@ -70,7 +70,7 @@ def cdf_match_lut(src_cdf, ref_cdf, dtype=np.uint8):
     Create a look up table for matching the source CDF to the reference CDF. At
     each intensity, this algorithm gets the value of the source CDF, then finds
     the intensity at which the reference CDF has the same value.
-    
+
     :param src_cdf:
         Source CDF represented as a 1d array.
     :param ref_cdf:
@@ -119,7 +119,7 @@ def cdf_match_lut(src_cdf, ref_cdf, dtype=np.uint8):
 def _check_cdf(cdf):
     """
     Checks that CDF monotonically increases and has a maximum value of 1.
-    
+
     .. todo:: Is this check necessary? Will np.cumsum() ever return a non-monotonically increasing function?
     """
 

--- a/color_balance/histogram_match.py
+++ b/color_balance/histogram_match.py
@@ -140,10 +140,10 @@ def mean_std_luts(in_img, ref_img, in_mask=None, ref_mask=None, dtype=np.uint16)
     # Create a 3d mask from the 2d mask
     # Numpy masked arrays treat True as masked values. Opposite of OpenCV
     if in_mask is not None:
-        indices = np.where(in_mask.astype(bool) == False)
-        r = in_img[:, :, 0][indices]
-        g = in_img[:, :, 1][indices]
-        b = in_img[:, :, 2][indices]
+        mask = ~in_mask.astype(bool)
+        r = in_img[:, :, 0][mask]
+        g = in_img[:, :, 1][mask]
+        b = in_img[:, :, 2][mask]
 
     else:
         r = in_img[:, :, 0]
@@ -154,10 +154,10 @@ def mean_std_luts(in_img, ref_img, in_mask=None, ref_mask=None, dtype=np.uint16)
     in_std = np.array([r.std(), g.std(), b.std()])
 
     if ref_mask is not None:
-        indices = np.where(ref_mask.astype(bool) == False)
-        r_ref = ref_img[:, :, 0][indices]
-        g_ref = ref_img[:, :, 1][indices]
-        b_ref = ref_img[:, :, 2][indices]
+        mask = ~ref_mask.astype(bool)
+        r_ref = ref_img[:, :, 0][mask]
+        g_ref = ref_img[:, :, 1][mask]
+        b_ref = ref_img[:, :, 2][mask]
     else:
         r_ref = ref_img[:, :, 0]
         g_ref = ref_img[:, :, 1]

--- a/tests/histogram_match_tests.py
+++ b/tests/histogram_match_tests.py
@@ -160,6 +160,32 @@ class Tests(unittest.TestCase):
              first_half_to_sequence_lut,
              second_half_to_sequence_lut])
 
+    def test_mean_std_12bit(self):
+        # Input 12-bit, with an 8-bit color target
+        input_scene = np.tile(np.arange(4096)[:, None, None], (1, 1, 3))
+        color_target = np.tile(np.arange(256)[:, None, None], (1, 1, 3))
+
+        luts = hm.mean_std_luts(input_scene.astype(np.uint16),
+                                color_target.astype(np.uint8))
+
+        np.testing.assert_array_equal(luts[0], luts[1])
+        np.testing.assert_array_equal(luts[1], luts[2])
+
+        lut = luts[0]
+        assert np.all(lut[:8] == 0)
+        assert np.all(lut[-8:] == 4096)
+        assert np.diff(lut[8:-8]).min() == 1
+        assert np.diff(lut[8:-8]).max() == 2
+
+        # Input 12-bit, with a 12-bit color target
+        input_scene = np.tile(np.arange(4096)[:, None, None], (1, 1, 3))
+        color_target = np.tile(np.arange(4096)[:, None, None], (1, 1, 3))
+
+        luts = hm.mean_std_luts(input_scene.astype(np.uint16),
+                                color_target.astype(np.uint16))
+
+        # Should be a 1 to 1 look-up-table...
+        np.testing.assert_array_equal(luts[0], np.arange(4097))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/histogram_match_tests.py
+++ b/tests/histogram_match_tests.py
@@ -123,11 +123,11 @@ class Tests(unittest.TestCase):
         match_cdf = np.array([0, 1])
         self.assertRaises(hm.CDFException, hm.cdf_match_lut, test_cdf, match_cdf)
 
-    @unittest.skip("TODO: Deprecate mean/std")
     def test_mean_std_luts(self):
         sequence_to_compressed_luts = hm.mean_std_luts(
             self.sequence_img,
-            self.compressed_img)
+            self.compressed_img,
+            dtype=np.uint8)
         sequence_to_spread_lut = np.array(
             [0]*15 + range(0, 49) + range(48, 176) + range(175, 239),
             dtype=np.uint8)
@@ -144,7 +144,8 @@ class Tests(unittest.TestCase):
 
         compressed_to_sequence_luts = hm.mean_std_luts(
             self.compressed_img,
-            self.sequence_img)
+            self.sequence_img,
+            dtype=np.uint8)
         spread_to_sequence_lut = np.array(
             range(14, 63) + range(64, 191) + range(192, 255) + [255] * 17,
             dtype=np.uint8)


### PR DESCRIPTION
Mean/Std-dev color balancing should work for 8-bit targets as well. 

cc @kjordahl
